### PR TITLE
Bump iteratee and catbird versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ val compilerOptions = Seq(
   "-Xfuture"
 )
 
-val iterateeVersion = "0.15.0"
-val catbirdVersion = "0.21.0"
+val iterateeVersion = "0.16.0"
+val catbirdVersion = "0.22.0"
 val disciplineVersion = "0.8"
 
 val scalaCheckVersion = "1.13.5"


### PR DESCRIPTION
For Catbird 0.22 and iteratee 0.16.

Needed for Finch release: https://github.com/finagle/finch/pull/881