### PR TITLE
update finagle version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val compilerOptions = Seq(
 )
 
 val iterateeVersion = "0.18.0"
-val catbirdVersion = "18.11.0"
+val catbirdVersion = "18.12.0"
 val disciplineVersion = "0.9.0"
 
 val scalaCheckVersion = "1.13.5"


### PR DESCRIPTION
Bump finagle to 18.12.0 (or wait a few days till 19.1.0?) Personally scala-steward has made these kinds of PR's a bit redundant. I'm not sure anyone else is using this though, still it would be a good idea. 